### PR TITLE
Changes to retry behaviour in libary.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node": "20.1.7",
         "@types/react": "18.2.6",
         "@types/react-dom": "18.2.4",
-        "async": "^3.2.4",
+        "async-retry": "^1.3.3",
         "client-only": "^0.0.1",
         "eslint": "8.40.0",
         "eslint-config-next": "13.4.2",
@@ -25,7 +25,7 @@
         "universal-cookie": "^4.0.4"
       },
       "devDependencies": {
-        "@types/async": "^3.2.20",
+        "@types/async-retry": "^1.4.5",
         "autoprefixer": "^10.4.14",
         "postcss": "^8.4.24",
         "prettier": "^2.8.8",
@@ -404,11 +404,14 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/async": {
-      "version": "3.2.20",
-      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.20.tgz",
-      "integrity": "sha512-6jSBQQugzyX1aWto0CbvOnmxrU9tMoXfA9gc4IrLEtvr3dTwSg5GLGoWiZnGLI6UG/kqpB3JOQKQrqnhUWGKQA==",
-      "dev": true
+    "node_modules/@types/async-retry": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/async-retry/-/async-retry-1.4.5.tgz",
+      "integrity": "sha512-YrdjSD+yQv7h6d5Ip+PMxh3H6ZxKyQk0Ts+PvaNRInxneG9PFVZjFg77ILAN+N6qYf7g4giSJ1l+ZjQ1zeegvA==",
+      "dev": true,
+      "dependencies": {
+        "@types/retry": "*"
+      }
     },
     "node_modules/@types/cookie": {
       "version": "0.3.3",
@@ -455,6 +458,12 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
+      "dev": true
     },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
@@ -740,10 +749,13 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag=="
     },
-    "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.14",
@@ -3711,6 +3723,14 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/node": "20.1.7",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",
-    "async": "^3.2.4",
+    "async-retry": "^1.3.3",
     "client-only": "^0.0.1",
     "eslint": "8.40.0",
     "eslint-config-next": "13.4.2",
@@ -27,7 +27,7 @@
     "universal-cookie": "^4.0.4"
   },
   "devDependencies": {
-    "@types/async": "^3.2.20",
+    "@types/async-retry": "^1.4.5",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.24",
     "prettier": "^2.8.8",

--- a/src/app/generate/page.tsx
+++ b/src/app/generate/page.tsx
@@ -50,17 +50,17 @@ async function Page({
     throw new Error("Could not verfiy accessTokenJWT");
   }
 
-  // FETCH STEP 1: Get all the user's song in the given time range
+  // GENERATE STEP 1: Get all the user's song in the given time range
   const tracks = await getFilteredLibrary(accessToken, minLength, maxLength);
 
   if (tracks.length == 0) {
     throw Error("No tracks in given range found.");
   }
 
-  // FETCH STEP 2: Create a new empty playlist
+  // GENERATE STEP 2: Create a new empty playlist
   const playlistID = await createPlaylist(accessToken, userID);
 
-  // FETCH STEP 3: Add the songs to the new playlist
+  // GENERATE STEP 3: Add the songs to the new playlist
   await populatePlaylist(accessToken, playlistID, tracks);
 
   redirect("/playlist/?id=" + playlistID);


### PR DESCRIPTION
The Vercel async-retry package is now used in lieu of the async package. The retry function has been moved to within fetchJSON, the timings have been adjusted and bail behaviour has been added in case of a 401, 403 or 429 status code from Spotify.