### PR TITLE
Allowing library fetching to slow down when rate limited

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/helpers/library.ts
+++ b/src/helpers/library.ts
@@ -149,9 +149,8 @@ export async function getFilteredLibrary(
 
         // Bail (do not retry) if the following status codes are encountered
         if (
-          response.status == 401 || // Bad or expired token
-          response.status == 403 || // Bad OAuth Request
-          response.status == 429 // The app has exceeded its rate limits
+          response.status == 401 // Bad or expired token
+          || response.status == 403 // Bad OAuth Request
         ) {
           bail(new Error(response.statusText));
         }
@@ -174,7 +173,7 @@ export async function getFilteredLibrary(
       },
       {
         retries: 10,
-        minTimeout: 100,
+        minTimeout: 500,
         maxTimeout: 5000,
       }
     );


### PR DESCRIPTION
Spotify must have adjusted their rates lately which introduced this bug. Now, if rate limited, the retry() will trigger, but will wait at least 500ms before doing so.